### PR TITLE
convert erl_anno:anno() to integer() at transform

### DIFF
--- a/src/logi_transform.erl
+++ b/src/logi_transform.erl
@@ -23,16 +23,16 @@
 %% Exported API
 %%----------------------------------------------------------------------------------------------------------------------
 -export([parse_transform/2]).
--export_type([form/0, line/0, expr/0, expr_call_remote/0, expr_var/0]).
+-export_type([form/0, line_or_anno/0, expr/0, expr_call_remote/0, expr_var/0]).
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Types & Records
 %%----------------------------------------------------------------------------------------------------------------------
--type form() :: {attribute, line(), atom(), term()}
-              | {function, line(), atom(), non_neg_integer(), [clause()]}
+-type form() :: {attribute, line_or_anno(), atom(), term()}
+              | {function, line_or_anno(), atom(), non_neg_integer(), [clause()]}
               | erl_parse:abstract_form().
 
--type clause() :: {clause, line(), [term()], [term()], [expr()]}
+-type clause() :: {clause, line_or_anno(), [term()], [term()], [expr()]}
                 | erl_parse:abstract_clause().
 
 -type expr() :: expr_call_remote()
@@ -40,17 +40,17 @@
               | erl_parse:abstract_expr()
               | term().
 
--type expr_call_remote() :: {call, line(), {remote, line(), expr(), expr()}, [expr()]}.
--type expr_var() :: {var, line(), atom()}.
+-type expr_call_remote() :: {call, line_or_anno(), {remote, line_or_anno(), expr(), expr()}, [expr()]}.
+-type expr_var() :: {var, line_or_anno(), atom()}.
 
--type line() :: non_neg_integer().
+-type line_or_anno() :: non_neg_integer() | erl_anno:anno().
 
 -record(location,
         {
-          application :: atom(),
-          module      :: module(),
-          function    :: atom(),
-          line        :: line()
+          application  :: atom(),
+          module       :: module(),
+          function     :: atom(),
+          line_or_anno :: line_or_anno()
         }).
 
 %%----------------------------------------------------------------------------------------------------------------------
@@ -60,9 +60,9 @@
 -spec parse_transform([form()], [compile:option()]) -> [form()].
 parse_transform(AbstractForms, Options) ->
     Loc = #location{
-             application = logi_transform_utils:guess_application(AbstractForms, Options),
-             module      = logi_transform_utils:get_module(AbstractForms),
-             line        = 0
+             application         = logi_transform_utils:guess_application(AbstractForms, Options),
+             module              = logi_transform_utils:get_module(AbstractForms),
+             line_or_anno        = 0
             },
     walk_forms(AbstractForms, Loc).
 
@@ -79,14 +79,14 @@ walk_forms(Forms, Loc) ->
 -spec walk_clauses([clause()], #location{}) -> [clause()].
 walk_clauses(Clauses, Loc) ->
     [case Clause of
-         {clause, Line, Args, Guards, Body} -> {clause, Line, Args, Guards, [walk_expr(E, Loc) || E <- Body]};
-         _                                  -> Clause
+         {clause, LineOrAnno, Args, Guards, Body} -> {clause, LineOrAnno, Args, Guards, [walk_expr(E, Loc) || E <- Body]};
+         _                                        -> Clause
      end || Clause <- Clauses].
 
 -spec walk_expr(expr(), #location{}) -> expr().
-walk_expr({call, Line, {remote, _, {atom, _, M}, {atom, _, F}}, _} = C0, Loc) ->
+walk_expr({call, LineOrAnno, {remote, _, {atom, _, M}, {atom, _, F}}, _} = C0, Loc) ->
     C1 = list_to_tuple(walk_expr_parts(tuple_to_list(C0), Loc)),
-    transform_call(M, F, C1, Loc#location{line = Line});
+    transform_call(M, F, C1, Loc#location{line_or_anno = LineOrAnno});
 walk_expr(Expr, Loc) when is_tuple(Expr) ->
     list_to_tuple(walk_expr_parts(tuple_to_list(Expr), Loc));
 walk_expr(Expr, Loc) when is_list(Expr) ->
@@ -101,7 +101,7 @@ walk_expr_parts(Parts, Loc) ->
 -spec transform_call(module(), atom(), expr_call_remote(), #location{}) -> expr().
 transform_call(logi_location, guess_location, _, Loc) ->
     logi_location_expr(Loc);
-transform_call(logi, Severity0, {_, _, _, Args} = Call, Loc = #location{line = Line}) ->
+transform_call(logi, Severity0, {_, _, _, Args} = Call, Loc = #location{line_or_anno = LineOrAnno}) ->
     Severity = normalize_severity(Severity0),
     case logi:is_severity(Severity) of
         false -> Call;
@@ -109,17 +109,17 @@ transform_call(logi, Severity0, {_, _, _, Args} = Call, Loc = #location{line = L
             case Args of
                 %% For maintaining compatibility with v0.0.12
                 [Logger, {string, _, _} = Fmt] ->
-                    Opts = {cons, Line, {tuple, Line, [{atom, Line, logger}, Logger]}, {nil, Line}},
-                    logi_call_expr(Severity, Fmt, {nil, Line}, Opts, Loc);
-                [Logger, {string, _, _} = Fmt, {nil, Line} = Data] ->
-                    Opts = {cons, Line, {tuple, Line, [{atom, Line, logger}, Logger]}, {nil, Line}},
+                    Opts = {cons, LineOrAnno, {tuple, LineOrAnno, [{atom, LineOrAnno, logger}, Logger]}, {nil, LineOrAnno}},
+                    logi_call_expr(Severity, Fmt, {nil, LineOrAnno}, Opts, Loc);
+                [Logger, {string, _, _} = Fmt, {nil, _} = Data] ->
+                    Opts = {cons, LineOrAnno, {tuple, LineOrAnno, [{atom, LineOrAnno, logger}, Logger]}, {nil, LineOrAnno}},
                     logi_call_expr(Severity, Fmt, Data, Opts, Loc);
                 [Logger, {string, _, _} = Fmt, {cons, _, _, _} = Data] ->
-                    Opts = {cons, Line, {tuple, Line, [{atom, Line, logger}, Logger]}, {nil, Line}},
+                    Opts = {cons, LineOrAnno, {tuple, LineOrAnno, [{atom, LineOrAnno, logger}, Logger]}, {nil, LineOrAnno}},
                     logi_call_expr(Severity, Fmt, Data, Opts, Loc);
 
-                [Fmt]             -> logi_call_expr(Severity, Fmt, {nil, Line}, {nil, Line}, Loc);
-                [Fmt, Data]       -> logi_call_expr(Severity, Fmt, Data,        {nil, Line}, Loc);
+                [Fmt]             -> logi_call_expr(Severity, Fmt, {nil, LineOrAnno}, {nil, LineOrAnno}, Loc);
+                [Fmt, Data]       -> logi_call_expr(Severity, Fmt, Data,        {nil, LineOrAnno}, Loc);
                 [Fmt, Data, Opts] -> logi_call_expr(Severity, Fmt, Data,        Opts,        Loc);
                 _                 -> Call
             end
@@ -128,33 +128,33 @@ transform_call(_, _, Call, _Loc) ->
     Call.
 
 -spec logi_location_expr(#location{}) -> expr().
-logi_location_expr(Loc = #location{line = Line}) ->
+logi_location_expr(Loc = #location{line_or_anno = LineOrAnno}) ->
     logi_transform_utils:make_call_remote(
-      Line, logi_location, unsafe_new,
+      LineOrAnno, logi_location, unsafe_new,
       [
-       {call, Line, {atom, Line, self}, []},
-       {atom, Line, Loc#location.application},
-       {atom, Line, Loc#location.module},
-       {atom, Line, Loc#location.function},
-       {integer, Line, Line}
+       {call, LineOrAnno, {atom, LineOrAnno, self}, []},
+       {atom, LineOrAnno, Loc#location.application},
+       {atom, LineOrAnno, Loc#location.module},
+       {atom, LineOrAnno, Loc#location.function},
+       {integer, LineOrAnno, logi_transform_utils:line_or_anno_to_line(LineOrAnno)}
       ]).
 
 -spec logi_call_expr(logi:severity(), expr(), expr(), expr(), #location{}) -> expr().
-logi_call_expr(Severity, FormatExpr, DataExpr, OptionsExpr, Loc = #location{line = Line}) ->
+logi_call_expr(Severity, FormatExpr, DataExpr, OptionsExpr, Loc = #location{line_or_anno = LineOrAnno}) ->
     LocationExpr = logi_location_expr(Loc),
-    LoggerVar = logi_transform_utils:make_var(Line, "__Logger"),
-    ResultVar = logi_transform_utils:make_var(Line, "__Result"),
+    LoggerVar = logi_transform_utils:make_var(LineOrAnno, "__Logger"),
+    ResultVar = logi_transform_utils:make_var(LineOrAnno, "__Result"),
     LogiReadyCall = logi_transform_utils:make_call_remote(
-                      Line, logi, '_ready', [{atom, Line, Severity}, LocationExpr, OptionsExpr]),
-    {'case', Line, LogiReadyCall,
+                      LineOrAnno, logi, '_ready', [{atom, LineOrAnno, Severity}, LocationExpr, OptionsExpr]),
+    {'case', LineOrAnno, LogiReadyCall,
      [
       %% {Logger, []} -> Logger
-      {clause, Line, [{tuple, Line, [LoggerVar, {nil, Line}]}], [],
+      {clause, LineOrAnno, [{tuple, LineOrAnno, [LoggerVar, {nil, LineOrAnno}]}], [],
        [LoggerVar]},
 
       %% {Logger, Result} -> logi:'_write'(Result, Format, Data), Logger
-      {clause, Line, [{tuple, Line, [LoggerVar, ResultVar]}], [],
-       [logi_transform_utils:make_call_remote(Line, logi, '_write', [ResultVar, FormatExpr, DataExpr]),
+      {clause, LineOrAnno, [{tuple, LineOrAnno, [LoggerVar, ResultVar]}], [],
+       [logi_transform_utils:make_call_remote(LineOrAnno, logi, '_write', [ResultVar, FormatExpr, DataExpr]),
         LoggerVar]}
      ]}.
 

--- a/src/logi_transform_utils.erl
+++ b/src/logi_transform_utils.erl
@@ -12,6 +12,7 @@
 -export([get_module/1]).
 -export([make_var/2]).
 -export([make_call_remote/4]).
+-export([line_or_anno_to_line/1]).
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported Functions
@@ -32,20 +33,26 @@ guess_application(Forms, Options) ->
     find_app_file([Dir || Dir <- [OutDir, SrcDir], Dir =/= undefined]).
 
 %% @doc Makes a abstract term for variable
--spec make_var(logi_transform:line(), string()) -> logi_transform:expr_var().
-make_var(Line, Prefix) ->
+-spec make_var(logi_transform:line_or_anno(), string()) -> logi_transform:expr_var().
+make_var(LineOrAnno, Prefix) ->
     Seq = case get({?MODULE, seq}) of
               undefined -> 0;
               Seq0      -> Seq0
           end,
     _ = put({?MODULE, seq}, Seq + 1),
-    Name = list_to_atom(Prefix ++ "_line" ++ integer_to_list(Line) ++ "_" ++ integer_to_list(Seq)),
-    {var, Line, Name}.
+    Name = list_to_atom(Prefix ++ "_line" ++ integer_to_list(line_or_anno_to_line(LineOrAnno)) ++ "_" ++ integer_to_list(Seq)),
+    {var, LineOrAnno, Name}.
 
 %% @doc Makes a abstract term for external function call
--spec make_call_remote(logi_transform:line(), module(), atom(), [logi_transform:expr()]) -> logi_transform:expr_call_remote().
-make_call_remote(Line, Module, Function, ArgsExpr) ->
-    {call, Line, {remote, Line, {atom, Line, Module}, {atom, Line, Function}}, ArgsExpr}.
+-spec make_call_remote(logi_transform:line_or_anno(), module(), atom(), [logi_transform:expr()]) -> logi_transform:expr_call_remote().
+make_call_remote(LineOrAnno, Module, Function, ArgsExpr) ->
+    {call, LineOrAnno, {remote, LineOrAnno, {atom, LineOrAnno, Module}, {atom, LineOrAnno, Function}}, ArgsExpr}.
+
+-spec line_or_anno_to_line(logi_transform:line_or_anno()) -> integer().
+line_or_anno_to_line(LineOrAnno) when is_integer(LineOrAnno)
+    -> LineOrAnno;
+line_or_anno_to_line(LineOrAnno)
+    -> erl_anno:line(LineOrAnno).
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Internal Functions

--- a/src/logi_transform_utils.erl
+++ b/src/logi_transform_utils.erl
@@ -32,20 +32,20 @@ guess_application(Forms, Options) ->
     find_app_file([Dir || Dir <- [OutDir, SrcDir], Dir =/= undefined]).
 
 %% @doc Makes a abstract term for variable
--spec make_var(logi_transform:line_or_anno(), string()) -> logi_transform:expr_var().
-make_var(LineOrAnno, Prefix) ->
+-spec make_var(logi_transform:line(), string()) -> logi_transform:expr_var().
+make_var(Line, Prefix) ->
     Seq = case get({?MODULE, seq}) of
               undefined -> 0;
               Seq0      -> Seq0
           end,
     _ = put({?MODULE, seq}, Seq + 1),
-    Name = list_to_atom(Prefix ++ "_line" ++ line_or_anno_to_string(LineOrAnno) ++ "_" ++ integer_to_list(Seq)),
-    {var, LineOrAnno, Name}.
+    Name = list_to_atom(Prefix ++ "_line" ++ integer_to_list(Line) ++ "_" ++ integer_to_list(Seq)),
+    {var, Line, Name}.
 
 %% @doc Makes a abstract term for external function call
--spec make_call_remote(logi_transform:line_or_anno(), module(), atom(), [logi_transform:expr()]) -> logi_transform:expr_call_remote().
-make_call_remote(LineOrAnno, Module, Function, ArgsExpr) ->
-    {call, LineOrAnno, {remote, LineOrAnno, {atom, LineOrAnno, Module}, {atom, LineOrAnno, Function}}, ArgsExpr}.
+-spec make_call_remote(logi_transform:line(), module(), atom(), [logi_transform:expr()]) -> logi_transform:expr_call_remote().
+make_call_remote(Line, Module, Function, ArgsExpr) ->
+    {call, Line, {remote, Line, {atom, Line, Module}, {atom, Line, Function}}, ArgsExpr}.
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Internal Functions
@@ -61,9 +61,3 @@ find_app_file([Dir | Dirs]) ->
             end;
         _ -> find_app_file(Dirs)
     end.
-
--spec line_or_anno_to_string(logi_transform:line_or_anno()) -> string().
-line_or_anno_to_string(LineOrAnno) when is_integer(LineOrAnno)
-    -> integer_to_list(LineOrAnno);
-line_or_anno_to_string(LineOrAnno)
-    -> integer_to_list(erl_anno:line(LineOrAnno)).

--- a/test/logi_location_tests.erl
+++ b/test/logi_location_tests.erl
@@ -59,18 +59,3 @@ guess_test_() ->
                ?assertEqual(undefined, logi_location:guess_application('UNDEFINED_MODULE'))
        end}
      ]}.
-
-anno_test_() ->
-    [
-     {"Creates a new location object",
-      fun () ->
-              L = logi_location:new(lists, map, erl_anno:new({12, 10})),
-              ?assert(logi_location:is_location(L)),
-              ?assertEqual(12, logi_location:get_line(L))
-      end},
-     {"Converts to a map without anno",
-      fun () ->
-              L = logi_location:new(lists, map, erl_anno:new({12, 10})),
-              ?assertMatch(#{line := 12}, logi_location:to_map(L))
-      end}
-    ].

--- a/test/logi_transform_tests.erl
+++ b/test/logi_transform_tests.erl
@@ -54,7 +54,25 @@ log_test_() ->
 
                %% [NO ERROR] transformed call
                Logger = logi:info("hello world"),
-               ?assertLog("hello world", [], fun (C) -> ?assertEqual(info, logi_context:get_severity(C)) end),
+               ?assertLog("hello world", [], fun (C) ->
+                   ?assertEqual(info, logi_context:get_severity(C)),
+                   ?assertEqual(56, logi_location:get_line(logi_context:get_location(C)))
+               end),
+               ?assert(logi:is_logger(Logger))
+       end},
+      {"`logi:Severity/Arity` with logger is transformed",
+       fun () ->
+               InstallSink(info),
+
+               %% [ERROR] function call
+               ?assertError(_, apply(logi, info, [logi:new([]), "hello world", []])),
+
+               %% [NO ERROR] transformed call
+               Logger = logi:info(logi:new([]), "hello world", []),
+               ?assertLog("hello world", [], fun (C) ->
+                   ?assertEqual(info, logi_context:get_severity(C)),
+                   ?assertEqual(71, logi_location:get_line(logi_context:get_location(C)))
+               end),
                ?assert(logi:is_logger(Logger))
        end},
       {"`Data` arugment will not be evaluated if it is unnecessary",

--- a/test/logi_transform_tests.erl
+++ b/test/logi_transform_tests.erl
@@ -54,10 +54,7 @@ log_test_() ->
 
                %% [NO ERROR] transformed call
                Logger = logi:info("hello world"),
-               ?assertLog("hello world", [], fun (C) ->
-                   ?assertEqual(info, logi_context:get_severity(C)),
-                   ?assertEqual(56, logi_location:get_line(logi_context:get_location(C)))
-               end),
+               ?assertLog("hello world", [], fun (C) -> ?assertEqual(info, logi_context:get_severity(C)) end),
                ?assert(logi:is_logger(Logger))
        end},
       {"`Data` arugment will not be evaluated if it is unnecessary",


### PR DESCRIPTION
The implementation of treating erl_anno:anno() in https://github.com/sile/logi/pull/3 has the following problems. (I'm very sorry.)

- `logi_location:unsafe_new/5` accepts `line_or_anno() :: line() | erl_anno:anno()` where `erl_anno:anno()` is opaque
    - when actual values like `{10, 12}` are placed after transform, dialyzer raises an error that says no compatible types
- `logi_transform:logi_location_expr/1` makes malformed abstract format values like `{integer, {10, 12}, {10, 12}}`
    - the third element of the tuple must be integer

This PR addresses these problems by converting `erl_anno:anno()` to `integer()` in the logi_transform process.
In addition, this fixes unintended pettern match in v0.0.12-compatible transform when Data is `[]`.